### PR TITLE
Fix GPG 1.x/2.x testing and usage

### DIFF
--- a/gpgme.go
+++ b/gpgme.go
@@ -169,6 +169,17 @@ func GetEngineInfo() (*EngineInfo, error) {
 	return info, handleError(C.gpgme_get_engine_info(&info.info))
 }
 
+func SetEngineInfo(proto Protocol, fileName, homeDir string) error {
+	cfn := C.CString(fileName)
+	defer C.free(unsafe.Pointer(cfn))
+	var chome *C.char
+	if homeDir != "" {
+		chome := C.CString(homeDir)
+		defer C.free(unsafe.Pointer(chome))
+	}
+	return handleError(C.gpgme_set_engine_info(C.gpgme_protocol_t(proto), cfn, chome))
+}
+
 func FindKeys(pattern string, secretOnly bool) ([]*Key, error) {
 	var keys []*Key
 	ctx, err := New()

--- a/gpgme.go
+++ b/gpgme.go
@@ -537,3 +537,12 @@ func (u *UserID) Comment() string {
 func (u *UserID) Email() string {
 	return C.GoString(u.u.email)
 }
+
+// This is somewhat of a horrible hack. We need to unset GPG_AGENT_INFO so that gpgme does not pass --use-agent to GPG.
+// os.Unsetenv should be enough, but that only calls the underlying C library (which gpgme uses) if cgo is involved
+// - and cgo can't be used in tests. So, provide this helper for test initialization.
+func unsetenvGPGAgentInfo() {
+	v := C.CString("GPG_AGENT_INFO")
+	defer C.free(unsafe.Pointer(v))
+	C.unsetenv(v)
+}

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -50,6 +50,7 @@ EV/5zFTEpzm4CtYHHdmY5uCaEJq/4hhE8BY8
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Setenv("GNUPGHOME", testGPGHome)
+	unsetenvGPGAgentInfo()
 	os.Exit(m.Run())
 }
 

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -135,8 +135,11 @@ func skipGPG2x(t *testing.T, msg string) {
 	info, err := GetEngineInfo()
 	checkError(t, err)
 	for info != nil {
-		if strings.Contains(info.FileName(), "gpg") && strings.HasPrefix(info.Version(), "2.") {
-			t.Skip(msg)
+		if info.Protocol() == ProtocolOpenPGP {
+			if strings.Contains(info.FileName(), "gpg") && strings.HasPrefix(info.Version(), "2.") {
+				t.Skip(msg)
+			}
+			return
 		}
 		info = info.Next()
 	}


### PR DESCRIPTION
- Fix the check whether GPG 2.x is being used
- Add `SetEngineInfo` to bindings
- Instead of immediately giving up when gpgme finds 2.x, check for the fairly common case of both being installed in `/usr/bin`, and explicitly use 1.x if so.
- Unset `GPG_AGENT_INFO` to make sure we don't ask for passwords in tests (seems necessary at least on Fedora 22).
