### PR TITLE
Fix and extend SetEngineInfo

### DIFF
--- a/gpgme.go
+++ b/gpgme.go
@@ -343,6 +343,19 @@ func (c *Context) EngineInfo() *EngineInfo {
 	return &EngineInfo{info: C.gpgme_ctx_get_engine_info(c.ctx)}
 }
 
+func (c *Context) SetEngineInfo(proto Protocol, fileName, homeDir string) error {
+	var cfn, chome *C.char
+	if fileName != "" {
+		cfn = C.CString(fileName)
+		defer C.free(unsafe.Pointer(cfn))
+	}
+	if homeDir != "" {
+		chome = C.CString(homeDir)
+		defer C.free(unsafe.Pointer(chome))
+	}
+	return handleError(C.gpgme_ctx_set_engine_info(c.ctx, C.gpgme_protocol_t(proto), cfn, chome))
+}
+
 func (c *Context) KeyListStart(pattern string, secretOnly bool) error {
 	cpattern := C.CString(pattern)
 	defer C.free(unsafe.Pointer(cpattern))

--- a/gpgme.go
+++ b/gpgme.go
@@ -202,11 +202,13 @@ func GetEngineInfo() (*EngineInfo, error) {
 }
 
 func SetEngineInfo(proto Protocol, fileName, homeDir string) error {
-	cfn := C.CString(fileName)
-	defer C.free(unsafe.Pointer(cfn))
-	var chome *C.char
+	var cfn, chome *C.char
+	if fileName != "" {
+		cfn = C.CString(fileName)
+		defer C.free(unsafe.Pointer(cfn))
+	}
 	if homeDir != "" {
-		chome := C.CString(homeDir)
+		chome = C.CString(homeDir)
 		defer C.free(unsafe.Pointer(chome))
 	}
 	return handleError(C.gpgme_set_engine_info(C.gpgme_protocol_t(proto), cfn, chome))

--- a/gpgme.go
+++ b/gpgme.go
@@ -41,14 +41,14 @@ type Protocol int
 
 const (
 	ProtocolOpenPGP  Protocol = C.GPGME_PROTOCOL_OpenPGP
-	ProtocolCMS               = C.GPGME_PROTOCOL_CMS
-	ProtocolGPGConf           = C.GPGME_PROTOCOL_GPGCONF
-	ProtocolAssuan            = C.GPGME_PROTOCOL_ASSUAN
-	ProtocolG13               = C.GPGME_PROTOCOL_G13
-	ProtocolUIServer          = C.GPGME_PROTOCOL_UISERVER
-	ProtocolSpawn             = C.GPGME_PROTOCOL_SPAWN
-	ProtocolDefault           = C.GPGME_PROTOCOL_DEFAULT
-	ProtocolUnknown           = C.GPGME_PROTOCOL_UNKNOWN
+	ProtocolCMS      Protocol = C.GPGME_PROTOCOL_CMS
+	ProtocolGPGConf  Protocol = C.GPGME_PROTOCOL_GPGCONF
+	ProtocolAssuan   Protocol = C.GPGME_PROTOCOL_ASSUAN
+	ProtocolG13      Protocol = C.GPGME_PROTOCOL_G13
+	ProtocolUIServer Protocol = C.GPGME_PROTOCOL_UISERVER
+	ProtocolSpawn    Protocol = C.GPGME_PROTOCOL_SPAWN
+	ProtocolDefault  Protocol = C.GPGME_PROTOCOL_DEFAULT
+	ProtocolUnknown  Protocol = C.GPGME_PROTOCOL_UNKNOWN
 )
 
 type PinEntryMode int

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -147,6 +147,24 @@ func TestContext_TextMode(t *testing.T) {
 	}
 }
 
+func TestContext_EngineInfo(t *testing.T) {
+	ctx, err := New()
+	checkError(t, err)
+
+	testProto := ProtocolOpenPGP
+	testFN := "testFN"
+	testHomeDir := "testHomeDir"
+	checkError(t, ctx.SetEngineInfo(testProto, testFN, testHomeDir))
+
+	info := ctx.EngineInfo()
+	compareEngineInfo(t, info, testProto, testFN, testHomeDir)
+
+	// SetEngineInfo with empty strings works, using defaults which we don't know,
+	// so just test that it doesn't fail.
+	checkError(t, ctx.SetEngineInfo(testProto, testFN, ""))
+	checkError(t, ctx.SetEngineInfo(testProto, "", testHomeDir))
+}
+
 func TestContext_Encrypt(t *testing.T) {
 	ctx, err := New()
 	checkError(t, err)


### PR DESCRIPTION
- Make all `Protocol`* constants typed, not just the first one.
- Fix `SetEngineInfo` with empty `homeDir`, support also empty `fileName`.
- Add `Context.SetEngineInfo`.