### PR TITLE
Fix NewDataBytes with an empty input

### DIFF
--- a/data.go
+++ b/data.go
@@ -92,7 +92,11 @@ func NewDataFile(f *os.File) (*Data, error) {
 // NewDataBytes returns a new memory based data buffer that contains `b` bytes
 func NewDataBytes(b []byte) (*Data, error) {
 	d := newData()
-	return d, handleError(C.gpgme_data_new_from_mem(&d.dh, (*C.char)(unsafe.Pointer(&b[0])), C.size_t(len(b)), 1))
+	var cb *C.char
+	if len(b) != 0 {
+		cb = (*C.char)(unsafe.Pointer(&b[0]))
+	}
+	return d, handleError(C.gpgme_data_new_from_mem(&d.dh, cb, C.size_t(len(b)), 1))
 }
 
 // NewDataReader returns a new callback based data buffer

--- a/data_test.go
+++ b/data_test.go
@@ -27,6 +27,21 @@ func TestNewData(t *testing.T) {
 	dh.Close()
 }
 
+func TestNewDataBytes(t *testing.T) {
+	// Test ordinary data, and empty slices
+	for _, content := range [][]byte{[]byte("content"), []byte{}} {
+		dh, err := NewDataBytes(content)
+		checkError(t, err)
+
+		_, err = dh.Seek(0, SeekSet)
+		checkError(t, err)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, dh)
+		checkError(t, err)
+		diff(t, buf.Bytes(), content)
+	}
+}
+
 func TestDataNewDataFile(t *testing.T) {
 	f, err := ioutil.TempFile("", "gpgme")
 	checkError(t, err)


### PR DESCRIPTION
`&b[0]` is invalid if `len(b) == 0`.