### PR TITLE
Fix callback handle pointers

### DIFF
--- a/data.go
+++ b/data.go
@@ -106,7 +106,7 @@ func NewDataReader(r io.Reader) (*Data, error) {
 	d.cbs.read = C.gpgme_data_read_cb_t(C.gogpgme_readfunc)
 	cbc := callbackAdd(d)
 	d.cbc = cbc
-	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&cbc)))
+	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&d.cbc)))
 }
 
 // NewDataWriter returns a new callback based data buffer
@@ -116,7 +116,7 @@ func NewDataWriter(w io.Writer) (*Data, error) {
 	d.cbs.write = C.gpgme_data_write_cb_t(C.gogpgme_writefunc)
 	cbc := callbackAdd(d)
 	d.cbc = cbc
-	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&cbc)))
+	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&d.cbc)))
 }
 
 // NewDataReadWriter returns a new callback based data buffer
@@ -128,7 +128,7 @@ func NewDataReadWriter(rw io.ReadWriter) (*Data, error) {
 	d.cbs.write = C.gpgme_data_write_cb_t(C.gogpgme_writefunc)
 	cbc := callbackAdd(d)
 	d.cbc = cbc
-	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&cbc)))
+	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&d.cbc)))
 }
 
 // NewDataReadWriteSeeker returns a new callback based data buffer
@@ -142,7 +142,7 @@ func NewDataReadWriteSeeker(rw io.ReadWriteSeeker) (*Data, error) {
 	d.cbs.seek = C.gpgme_data_seek_cb_t(C.gogpgme_seekfunc)
 	cbc := callbackAdd(d)
 	d.cbc = cbc
-	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&cbc)))
+	return d, handleError(C.gpgme_data_new_from_cbs(&d.dh, &d.cbs, unsafe.Pointer(&d.cbc)))
 }
 
 // Close releases any resources associated with the data buffer

--- a/gpgme.go
+++ b/gpgme.go
@@ -331,7 +331,7 @@ func (c *Context) SetCallback(callback Callback) error {
 	if callback != nil {
 		cbc := callbackAdd(c)
 		c.cbc = cbc
-		_, err = C.gpgme_set_passphrase_cb(c.ctx, C.gpgme_passphrase_cb_t(C.gogpgme_passfunc), unsafe.Pointer(&cbc))
+		_, err = C.gpgme_set_passphrase_cb(c.ctx, C.gpgme_passphrase_cb_t(C.gogpgme_passfunc), unsafe.Pointer(&c.cbc))
 	} else {
 		c.cbc = 0
 		_, err = C.gpgme_set_passphrase_cb(c.ctx, nil, nil)


### PR DESCRIPTION
Use pointers to the relevant data structures which live as long as the callbacks can be called, not pointers to local variables which go away immediately.

(This is noticeable e.g. on CentOS 7, already in `go test`. It is quite suprising that this has worked just fine on other platforms so far. :) )