### PR TITLE
Add missing #include <stdint.h>

### DIFF
--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -1,6 +1,8 @@
 #ifndef GO_GPGME_H
 #define GO_GPGME_H
 
+#include <stdint.h>
+
 #include <gpgme.h>
 
 extern ssize_t gogpgme_readfunc(void *handle, void *buffer, size_t size);


### PR DESCRIPTION
We use the `uintptr_t` type, so we should be including the appropriate header file.

Recent versions of `gpg-error.h` include `stdint.h`, so this works out; older versions, like in RHEL 7, do not.

(This is not sufficient to build the package on RHEL 7, and that is not the ambition; it is just a correctness cleanup that happens to be immediately needed on RHEL 7.)