### PR TITLE
Define _FILE_OFFSET_BITS=64 to fix build on 32-bit platforms

### DIFF
--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -1,6 +1,7 @@
 #ifndef GO_GPGME_H
 #define GO_GPGME_H
 
+#define _FILE_OFFSET_BITS 64
 #include <stdint.h>
 
 #include <gpgme.h>

--- a/gpgme.go
+++ b/gpgme.go
@@ -2,6 +2,7 @@
 package gpgme
 
 // #cgo LDFLAGS: -lgpgme -lassuan -lgpg-error
+// #cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
 // #include <stdlib.h>
 // #include <gpgme.h>
 // #include "go_gpgme.h"


### PR DESCRIPTION
Without this, build fails with:
```
In file included from /usr/include/gpgme.h:12:0,
                 from vendor/src/github.com/mtrmac/gpgme/data.go:4:
/usr/include/gpgme-32.h:90:2: error: #error GPGME was compiled with _FILE_OFFSET_BITS = 64, please see the section "Largefile support (LFS)" in the GPGME manual.
 #error GPGME was compiled with _FILE_OFFSET_BITS = 64, please see the section "Largefile support (LFS)" in the GPGME manual.
  ^~~~~
```

See `info gpgme 'Largefile support (LFS)'` .

The `#cgo CPPFLAGS:` declaration applies to the whole package, it is not necessary to repeat it in other .go files.

`go_gpgme.h` has an explicit `#define` anyway, to be a valid stand-alone C source.