### PR TITLE
Add AssuanSend and Export

### DIFF
--- a/go_gpgme.c
+++ b/go_gpgme.c
@@ -8,6 +8,24 @@ void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintpt
 	gpgme_set_passphrase_cb(ctx, cb, (void *)handle);
 }
 
+gpgme_error_t gogpgme_op_assuan_transact_ext(
+		gpgme_ctx_t ctx,
+		char* cmd,
+		uintptr_t data_h,
+		uintptr_t inquiry_h,
+		uintptr_t status_h,
+		gpgme_error_t *operr
+	){
+	return gpgme_op_assuan_transact_ext(
+		ctx,
+		cmd,
+		(gpgme_assuan_data_cb_t)    gogpgme_assuan_data_callback,    (void *)data_h,
+		(gpgme_assuan_inquire_cb_t) gogpgme_assuan_inquiry_callback, (void *)inquiry_h,
+		(gpgme_assuan_status_cb_t)  gogpgme_assuan_status_callback,  (void *)status_h,
+		operr
+	);
+}
+
 unsigned int key_revoked(gpgme_key_t k) {
 	return k->revoked;
 }

--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -13,6 +13,9 @@ extern gpgme_error_t gogpgme_passfunc(void *hook, char *uid_hint, char *passphra
 extern gpgme_error_t gogpgme_data_new_from_cbs(gpgme_data_t *dh, gpgme_data_cbs_t cbs, uintptr_t handle);
 extern void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintptr_t handle);
 
+extern gpgme_error_t gogpgme_assuan_data_callback(void *opaque, void* data, size_t datalen );
+extern gpgme_error_t gogpgme_assuan_status_callback(void *opaque, char* status, char* args);
+
 extern unsigned int key_revoked(gpgme_key_t k);
 extern unsigned int key_expired(gpgme_key_t k);
 extern unsigned int key_disabled(gpgme_key_t k);

--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -14,6 +14,7 @@ extern gpgme_error_t gogpgme_data_new_from_cbs(gpgme_data_t *dh, gpgme_data_cbs_
 extern void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintptr_t handle);
 
 extern gpgme_error_t gogpgme_assuan_data_callback(void *opaque, void* data, size_t datalen );
+extern gpgme_error_t gogpgme_assuan_inquiry_callback(void *opaque, char* name, char* args);
 extern gpgme_error_t gogpgme_assuan_status_callback(void *opaque, char* status, char* args);
 
 extern unsigned int key_revoked(gpgme_key_t k);

--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -13,6 +13,8 @@ extern gpgme_error_t gogpgme_passfunc(void *hook, char *uid_hint, char *passphra
 extern gpgme_error_t gogpgme_data_new_from_cbs(gpgme_data_t *dh, gpgme_data_cbs_t cbs, uintptr_t handle);
 extern void gogpgme_set_passphrase_cb(gpgme_ctx_t ctx, gpgme_passphrase_cb_t cb, uintptr_t handle);
 
+extern gpgme_error_t gogpgme_op_assuan_transact_ext(gpgme_ctx_t ctx, char *cmd, uintptr_t data_h, uintptr_t inquiry_h , uintptr_t status_h, gpgme_error_t *operr);
+
 extern gpgme_error_t gogpgme_assuan_data_callback(void *opaque, void* data, size_t datalen );
 extern gpgme_error_t gogpgme_assuan_inquiry_callback(void *opaque, char* name, char* args);
 extern gpgme_error_t gogpgme_assuan_status_callback(void *opaque, char* status, char* args);

--- a/gpgme.go
+++ b/gpgme.go
@@ -488,14 +488,18 @@ func (c *Context) AssuanSend(
 	statusPtr := callbackAdd(&status)
 	cmdCStr := C.CString(cmd)
 	defer C.free(unsafe.Pointer(cmdCStr))
-	err := C.gpgme_op_assuan_transact_ext(
+	err := C.gogpgme_op_assuan_transact_ext(
 		c.ctx,
 		cmdCStr,
-		C.gpgme_assuan_data_cb_t(unsafe.Pointer(C.gogpgme_assuan_data_callback)), unsafe.Pointer(dataPtr),
-		C.gpgme_assuan_data_cb_t(unsafe.Pointer(C.gogpgme_assuan_inquiry_callback)), unsafe.Pointer(inquiryPtr),
-		C.gpgme_assuan_data_cb_t(unsafe.Pointer(C.gogpgme_assuan_status_callback)), unsafe.Pointer(statusPtr),
+		C.uintptr_t(dataPtr),
+		C.uintptr_t(inquiryPtr),
+		C.uintptr_t(statusPtr),
 		&operr,
 	)
+
+	if handleError(operr) != nil {
+		return handleError(operr)
+	}
 	return handleError(err)
 }
 

--- a/gpgme.go
+++ b/gpgme.go
@@ -533,8 +533,21 @@ func gogpgme_assuan_status_callback(handle unsafe.Pointer, cStatus *C.char, cArg
 	return 0
 }
 
-func (c *Context) Export(keyid uint64, data *Data) error {
-	return handleError(C.gpgme_op_export(c.ctx, nil, 0, data.dh))
+// ExportModeFlags defines how keys are exported from Export
+type ExportModeFlags uint
+
+const (
+	ExportModeExtern  ExportModeFlags = C.GPGME_EXPORT_MODE_EXTERN
+	ExportModeMinimal ExportModeFlags = C.GPGME_EXPORT_MODE_MINIMAL
+	ExportModeSecret  ExportModeFlags = C.GPGME_EXPORT_MODE_SECRET
+	ExportModeRaw     ExportModeFlags = C.GPGME_EXPORT_MODE_RAW
+	ExportModePKCS12  ExportModeFlags = C.GPGME_EXPORT_MODE_PKCS12
+)
+
+func (c *Context) Export(pattern string, mode ExportModeFlags, data *Data) error {
+	pat := C.CString(pattern)
+	defer C.free(unsafe.Pointer(pat))
+	return handleError(C.gpgme_op_export(c.ctx, pat, C.gpgme_export_mode_t(mode), data.dh))
 }
 
 // ImportStatusFlags describes the type of ImportStatus.Status. The C API in gpgme.h simply uses "unsigned".

--- a/gpgme.go
+++ b/gpgme.go
@@ -509,8 +509,6 @@ func (c *Context) AssuanSend(cmd string, callback AssuanStatusCB) error {
 //export gogpgme_assuan_data_callback
 func gogpgme_assuan_data_callback(opaque unsafe.Pointer, data unsafe.Pointer, datalen C.size_t) C.gpgme_error_t {
 	datastr := C.GoStringN((*C.char)(data), (C.int)(datalen))
-	fmt.Println("data callback called")
-	fmt.Println(datastr)
 	return 0
 }
 
@@ -526,7 +524,6 @@ func gogpgme_assuan_status_callback(opaque unsafe.Pointer, cStatus *C.char, cArg
 
 func (c *Context) Export(keyid uint64) []byte {
 	data, _ := NewData()
-	//c.SetArmor(true)
 	err := handleError(C.gpgme_op_export(c.ctx, nil, 0, data.dh))
 	data.Seek(0, 0)
 	out, err := ioutil.ReadAll(data)

--- a/gpgme.go
+++ b/gpgme.go
@@ -8,9 +8,7 @@ package gpgme
 // #include "go_gpgme.h"
 import "C"
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"time"
@@ -535,15 +533,8 @@ func gogpgme_assuan_status_callback(handle unsafe.Pointer, cStatus *C.char, cArg
 	return 0
 }
 
-func (c *Context) Export(keyid uint64) []byte {
-	data, _ := NewData()
-	err := handleError(C.gpgme_op_export(c.ctx, nil, 0, data.dh))
-	data.Seek(0, 0)
-	out, err := ioutil.ReadAll(data)
-	if err != nil {
-		fmt.Println("Error reading data")
-	}
-	return out
+func (c *Context) Export(keyid uint64, data *Data) error {
+	return handleError(C.gpgme_op_export(c.ctx, nil, 0, data.dh))
 }
 
 // ImportStatusFlags describes the type of ImportStatus.Status. The C API in gpgme.h simply uses "unsigned".

--- a/gpgme.go
+++ b/gpgme.go
@@ -523,6 +523,19 @@ func gogpgme_assuan_status_callback(opaque unsafe.Pointer, cStatus *C.char, cArg
 
 	return 0
 }
+
+func (c *Context) Export(keyid uint64) []byte {
+	data, _ := NewData()
+	//c.SetArmor(true)
+	err := handleError(C.gpgme_op_export(c.ctx, nil, 0, data.dh))
+	data.Seek(0, 0)
+	out, err := ioutil.ReadAll(data)
+	if err != nil {
+		fmt.Println("Error reading data")
+	}
+	return out
+}
+
 // ImportStatusFlags describes the type of ImportStatus.Status. The C API in gpgme.h simply uses "unsigned".
 type ImportStatusFlags uint
 

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -342,6 +343,53 @@ func TestContext_Export(t *testing.T) {
 	if len(allKeys) < 1 {
 		t.Error("Expected exported keys, got empty buffer")
 	}
+}
+
+func TestContext_AssuanSend(t *testing.T) {
+
+	// gpg-agent might fail to start from the test directory, because
+	// the path might be longer than 108 characters, which is the maximum
+	// length for a unix socket
+	tmpdir, err := ioutil.TempDir("", "gpgme-")
+	checkError(t, err)
+	defer os.RemoveAll(tmpdir)
+
+	// Temporarily set up GNUPGHOME to a different location
+	os.Setenv("GNUPGHOME", tmpdir)
+	defer os.Setenv("GNUPGHOME", testGPGHome)
+
+	// Launch a gpg-agent in daemon mode
+	cmd := exec.Command("gpg-agent", "--daemon")
+	err = cmd.Start()
+	checkError(t, err)
+
+	ctx, err := New()
+	checkError(t, err)
+	err = ctx.SetProtocol(ProtocolAssuan)
+	checkError(t, err)
+
+	// NOP should simply succeed
+	err = ctx.AssuanSend("NOP", nil, nil, nil)
+	checkError(t, err)
+
+	// GETINFO should return a version in Data
+	var versionData []byte
+	err = ctx.AssuanSend("GETINFO version",
+		func(data []byte) error {
+			versionData = data
+			return nil
+		},
+		nil,
+		nil,
+	)
+	checkError(t, err)
+	if len(versionData) == 0 {
+		t.Error("Expected version data")
+	}
+
+	// Kill the gpg-agent started earlier
+	err = ctx.AssuanSend("KILLAGENT", nil, nil, nil)
+	checkError(t, err)
 }
 
 func isGPG2x(t *testing.T) (bool, string) {

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -327,38 +327,20 @@ func TestContext_Import(t *testing.T) {
 }
 
 func TestContext_Export(t *testing.T) {
-	homeDir, err := ioutil.TempDir("", "gpgme-import-test")
-	checkError(t, err)
-	defer os.RemoveAll(homeDir)
-
 	ctx, err := New()
-	checkError(t, err)
-	checkError(t, ctx.SetEngineInfo(ProtocolOpenPGP, "", homeDir))
-
-	f, err := os.Open("./testdata/pubkeys.gpg")
-	checkError(t, err)
-	defer f.Close()
-	dh, err := NewDataFile(f)
-	checkError(t, err)
-	defer dh.Close()
-
-	_, err = ctx.Import(dh)
 	checkError(t, err)
 
 	data, err := NewData()
 	checkError(t, err)
 
-	err = ctx.Export(0, data)
+	err = ctx.Export("", 0, data)
 	checkError(t, err)
 
 	data.Seek(0, 0)
 	allKeys, err := ioutil.ReadAll(data)
 	checkError(t, err)
-	if len(allKeys) == 0 {
-		t.Errorf("Failed to read keys")
-	}
-	if len(allKeys) != 1179 {
-		t.Errorf("Unexpected number of bytes exported")
+	if len(allKeys) < 1 {
+		t.Error("Expected exported keys, got empty buffer")
 	}
 }
 

--- a/gpgme_test.go
+++ b/gpgme_test.go
@@ -326,6 +326,42 @@ func TestContext_Import(t *testing.T) {
 	}
 }
 
+func TestContext_Export(t *testing.T) {
+	homeDir, err := ioutil.TempDir("", "gpgme-import-test")
+	checkError(t, err)
+	defer os.RemoveAll(homeDir)
+
+	ctx, err := New()
+	checkError(t, err)
+	checkError(t, ctx.SetEngineInfo(ProtocolOpenPGP, "", homeDir))
+
+	f, err := os.Open("./testdata/pubkeys.gpg")
+	checkError(t, err)
+	defer f.Close()
+	dh, err := NewDataFile(f)
+	checkError(t, err)
+	defer dh.Close()
+
+	_, err = ctx.Import(dh)
+	checkError(t, err)
+
+	data, err := NewData()
+	checkError(t, err)
+
+	err = ctx.Export(0, data)
+	checkError(t, err)
+
+	data.Seek(0, 0)
+	allKeys, err := ioutil.ReadAll(data)
+	checkError(t, err)
+	if len(allKeys) == 0 {
+		t.Errorf("Failed to read keys")
+	}
+	if len(allKeys) != 1179 {
+		t.Errorf("Unexpected number of bytes exported")
+	}
+}
+
 func isGPG2x(t *testing.T) (bool, string) {
 	var info *EngineInfo
 	info, err := GetEngineInfo()


### PR DESCRIPTION
This adds support for Export and AssuanSend. The AssuanSend uses a slightly different way of managing callabcks than the original code, which takes the callback as an argument instead of using a global. If this seems ok, perhaps the rest of the API could be modified to this style too?
