### PR TITLE
Add module metadata.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/proglottis/gpgme


### PR DESCRIPTION
Now that go 1.11 has module support, add metadata.

Please tag this module with a semantic versioning-compatible version (i.e. vN.M(.nn)), that would help.