### PR TITLE
Remove LD_FLAGS

### DIFF
--- a/gpgme.go
+++ b/gpgme.go
@@ -2,7 +2,6 @@
 package gpgme
 
 // #cgo pkg-config: gpgme
-// #cgo LDFLAGS: -lgpgme -lassuan -lgpg-error
 // #cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
 // #include <stdlib.h>
 // #include <gpgme.h>


### PR DESCRIPTION
Now that the linker is configured using pkg-config, there's no need to
manually declare the libraries to link.