### PR TITLE
Various IO-related bug fixes

### DIFF
--- a/data.go
+++ b/data.go
@@ -156,10 +156,10 @@ func (d *Data) Close() error {
 	if d.cbc > 0 {
 		d.cbc.Delete()
 	}
-	_, err := C.gpgme_data_release(d.dh)
+	C.gpgme_data_release(d.dh)
 	runtime.KeepAlive(d)
 	d.dh = nil
-	return err
+	return nil
 }
 
 func (d *Data) Write(p []byte) (int, error) {

--- a/data.go
+++ b/data.go
@@ -175,7 +175,7 @@ func (d *Data) Write(p []byte) (int, error) {
 		defer func() { d.err = nil }()
 
 		return 0, d.err
-	case err != nil:
+	case n < 0:
 		return 0, err
 	case len(p) > 0 && n == 0:
 		return 0, io.EOF
@@ -196,7 +196,7 @@ func (d *Data) Read(p []byte) (int, error) {
 		defer func() { d.err = nil }()
 
 		return 0, d.err
-	case err != nil:
+	case n < 0:
 		return 0, err
 	case len(p) > 0 && n == 0:
 		return 0, io.EOF
@@ -212,7 +212,7 @@ func (d *Data) Seek(offset int64, whence int) (int64, error) {
 		defer func() { d.err = nil }()
 
 		return 0, d.err
-	case err != nil:
+	case n < 0:
 		return 0, err
 	}
 	return int64(n), nil

--- a/data_test.go
+++ b/data_test.go
@@ -161,6 +161,16 @@ func (w *invalidShortWriter) Write(p []byte) (int, error) {
 
 func testReader(t testing.TB, r io.Reader, content []byte) {
 	var buf bytes.Buffer
+
+	// Reading into a 0-byte slice should return n == 0.
+	n1, err := r.Read([]byte{})
+	if n1 != 0 {
+		t.Errorf("Read([]byte{}) = %d", n1)
+	}
+	if len(content) > 0 && err != nil { // Getting io.EOF on 0-byte content is valid.
+		t.Errorf("Read([]byte{}) error %v", err)
+	}
+
 	n, err := io.Copy(&buf, r)
 	checkError(t, err)
 

--- a/data_test.go
+++ b/data_test.go
@@ -129,6 +129,36 @@ func TestData_callback_writing_error(t *testing.T) {
 	checkError(t, dh.Close())
 }
 
+func TestData_callback_writing_short(t *testing.T) {
+	shortWriter := &invalidShortWriter{maxWrite: 3}
+	dh, err := NewDataWriter(shortWriter)
+	checkError(t, err)
+	defer dh.Close()
+
+	// Write should loop and write all data despite short writes
+	_, err = dh.Write([]byte("test data"))
+	checkError(t, err)
+
+	expected := []byte("test data")
+	diff(t, shortWriter.written, expected)
+}
+
+// invalidShortWriter is an INVALID io.Writer implementation which succeeds with a short write.
+// We use it to simulate gpgme_data_write returning a short write, which is legitimate.
+type invalidShortWriter struct {
+	maxWrite int
+	written  []byte
+}
+
+func (w *invalidShortWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	if n > w.maxWrite {
+		n = w.maxWrite
+	}
+	w.written = append(w.written, p[:n]...)
+	return n, nil
+}
+
 func testReader(t testing.TB, r io.Reader, content []byte) {
 	var buf bytes.Buffer
 	n, err := io.Copy(&buf, r)

--- a/gpgme.go
+++ b/gpgme.go
@@ -377,20 +377,19 @@ func (c *Context) PinEntryMode() PinEntryMode {
 }
 
 func (c *Context) SetCallback(callback Callback) error {
-	var err error
 	c.callback = callback
 	if c.cbc > 0 {
 		c.cbc.Delete()
 	}
 	if callback != nil {
 		c.cbc = cgo.NewHandle(c)
-		_, err = C.gpgme_set_passphrase_cb(c.ctx, C.gpgme_passphrase_cb_t(C.gogpgme_passfunc), unsafe.Pointer(&c.cbc))
+		C.gpgme_set_passphrase_cb(c.ctx, C.gpgme_passphrase_cb_t(C.gogpgme_passfunc), unsafe.Pointer(&c.cbc))
 	} else {
 		c.cbc = 0
-		_, err = C.gpgme_set_passphrase_cb(c.ctx, nil, nil)
+		C.gpgme_set_passphrase_cb(c.ctx, nil, nil)
 	}
 	runtime.KeepAlive(c)
-	return err
+	return nil
 }
 
 func (c *Context) EngineInfo() *EngineInfo {


### PR DESCRIPTION
- Don’t inspect `errno` in calls that don’t set it
- On calls that do set `errno`, inspect it only when it is known to be valid
- Correctly implement `io.Writer`.

Partially addresses #45 .