### PR TITLE
Update from very old GnuPG 1.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - run: brew install gpgme gnupg@1.4
+      - run: brew install gpgme gnupg
       - uses: actions/setup-go@v3
         with:
           go-version: '1.17.12'


### PR DESCRIPTION
The last release was 1.4.23 in Jun 2018; it's not very relevant in modern environments.

More importantly, the unit tests have been consistently failing on macOS recently, and per https://github.com/proglottis/gpgme/pull/48 it seems that the underlying GnuPG does not provide the expected output, and updating GnuPG fixes that.

We've been pinned to 1.x for `ctx.SetCallback`, but that feature now exists in 2.x as well, as long as callers opt in. So, do so.